### PR TITLE
Make SamplesNotFoundException inherit from Exception

### DIFF
--- a/kattis-test
+++ b/kattis-test
@@ -14,7 +14,7 @@ from io import BytesIO
 
 SAMPLE_CACHE_DIR = Path.home() / '.config' / 'kattis-test'
 
-class SamplesNotFoundException(BaseException):
+class SamplesNotFoundException(Exception):
 	pass
 
 


### PR DESCRIPTION
SamplesNotFoundException is currently not caught by `catch Exception as e`.
See https://docs.python.org/3/library/exceptions.html#BaseException