### PR TITLE
Fix guess of problem id from problem letter

### DIFF
--- a/kattis-test
+++ b/kattis-test
@@ -512,7 +512,7 @@ def get_contest_problem_id(problem_letter: str, contest_url: str) -> str | None:
 
         response = str(response, "utf-8")
 
-        if 'class="problem_letter"' not in response:
+        if "<th>A</th>" not in response:
             return None
 
         problem_ids = []


### PR DESCRIPTION
The separate kattis instances for contests have been changed.
The /problems page at the root of the subdomain no longer lists problem letters (which makes it hard to distinguish from `open.kattis.com`), but the /contests/<contest_id>/problems page does.