### PR TITLE
Measure float diff for non-integers only & large float error => WA

### DIFF
--- a/kattis-test
+++ b/kattis-test
@@ -444,6 +444,9 @@ def normalize_output(s: str) -> str:
     return "\n".join([line.strip() for line in s.strip().split("\n")])
 
 
+INT_RE = re.compile(r"^-?\d+$")
+
+
 def get_float_diff(s1: str, s2: str) -> tuple[float, float] | None:
     reld = 0
     absd = 0
@@ -462,6 +465,8 @@ def get_float_diff(s1: str, s2: str) -> tuple[float, float] | None:
         for v1, v2 in zip(vs1, vs2):
             if v1 == v2:
                 continue
+            if INT_RE.match(v1) and INT_RE.match(v2):
+                return None
 
             try:
                 f1 = float(v1)

--- a/kattis-test
+++ b/kattis-test
@@ -500,7 +500,7 @@ def print_diff(output: str, expected_output: str) -> None:
 
 
 def compare_outputs(
-    output: str, expected_output: str, time_str: str, diff: bool
+    output: str, expected_output: str, time_str: str, diff: bool, float_tolerance: float
 ) -> bool:
     if output == expected_output:
         print(f"Success ({time_str})")
@@ -512,13 +512,18 @@ def compare_outputs(
         if absd < 1.0:
             if absd == 0.0 and reld == 0.0:
                 print(f"Ok with no float error ({time_str})")
-            else:
-                print(f"Ok with float error ({time_str}):")
-                print(f"  {absd:e} absolute")
-                print(f"  {reld:e} relative")
-                print(f"  {min(absd, reld):e} min")
+                return True
 
-            return True
+            mind = min(absd, reld)
+            if ok := mind <= float_tolerance:
+                print(f"OK with float error ({time_str}):")
+            else:
+                print(f"Wrong output ({time_str}), float error >{float_tolerance:e}:")
+
+            print(f"  {absd:e} absolute")
+            print(f"  {reld:e} relative")
+            print(f"  {mind:e} min")
+            return ok
 
     if diff:
         print(f"Wrong output ({time_str}), diff:")
@@ -758,6 +763,12 @@ def main() -> int:
         default=[],
         help="define a C++ macro",
     )
+    parser.add_argument(
+        "--float-tolerance",
+        type=float,
+        default=1e-7,
+        help="set float diff tolerance (default: 1e-7)",
+    )
     parser.add_argument("file", type=file_path)
 
     args = parser.parse_args()
@@ -871,7 +882,9 @@ def main() -> int:
                 with open(sample.output) as f:
                     expected_output = normalize_output(f.read())
 
-                success = compare_outputs(output, expected_output, time_str, args.diff)
+                success = compare_outputs(
+                    output, expected_output, time_str, args.diff, args.float_tolerance
+                )
                 all_correct &= success
             elif not args.show_output:
                 print(f"Output ({time_str}):")


### PR DESCRIPTION
Avoids false negatives with extremely large integers (e.g. in problems with long bit strings as output).
Fixes #7.